### PR TITLE
Inject credentials

### DIFF
--- a/lib/shorturl.rb
+++ b/lib/shorturl.rb
@@ -30,19 +30,19 @@ module ShortURL
   # parameters set so that when +instance+.call is invoked, the
   # shortened URL is returned.
   SERVICES = {
-    :tinyurl => Services::TinyURL.new,
-    :shorl => Services::Shorl.new,
-    :snipurl => Services::SnipURL.new,
-    :metamark => Services::Metamark.new,
-    :minilink => Services::Minilink.new,
-    :lns => Services::Lns.new,
-    :moourl => Services::MooURL.new,
-    :bitly => Services::Bitly.new,
-    :ur1 => Services::Url.new,
-    :vurl => Services::Vurl.new,
-    :isgd => Services::Isgd.new,
-    :gitio => Services::Gitio.new,
-    :vamu => Services::Vamu.new,
+    :tinyurl => Services::TinyURL,
+    :shorl => Services::Shorl,
+    :snipurl => Services::SnipURL,
+    :metamark => Services::Metamark,
+    :minilink => Services::Minilink,
+    :lns => Services::Lns,
+    :moourl => Services::MooURL,
+    :bitly => Services::Bitly,
+    :ur1 => Services::Url,
+    :vurl => Services::Vurl,
+    :isgd => Services::Isgd,
+    :gitio => Services::Gitio,
+    :vamu => Services::Vamu,
 
     # :skinnylink => Service.new("skinnylink.com") { |s|
     #   s.block = lambda { |body| URI.extract(body).grep(/skinnylink/)[0] }
@@ -126,9 +126,10 @@ module ShortURL
   # call-seq:
   #   ShortURL.shorten("http://mypage.com") => Uses TinyURL
   #   ShortURL.shorten("http://mypage.com", :bitly)
-  def self.shorten(url, service = :tinyurl)
+  def self.shorten(url, service = :tinyurl, credentials = nil)
     if SERVICES.has_key?(service)
-      SERVICES[service].call(url)
+      credentials ||= self.credentials_for(service.to_s)
+      SERVICES[service].new(credentials).call(url)
     else
       raise InvalidService
     end

--- a/lib/shorturl/service.rb
+++ b/lib/shorturl/service.rb
@@ -15,7 +15,7 @@ module ShortURL
     # return code, the form method to use, the form action, the form
     # field which contains the long URL, and the block of what to do
     # with the HTML code you get.
-    def initialize(hostname) # :yield: service
+    def initialize(hostname, creds = nil) # :yield: service
       @hostname = hostname
       @port = 80
       @code = 200

--- a/lib/shorturl/services/bitly.rb
+++ b/lib/shorturl/services/bitly.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Bitly < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("api-ssl.bitly.com")
 
         @method = :get
@@ -12,7 +12,6 @@ module ShortURL
         @ssl = true
         @action = "/v3/shorten/"
 
-        creds = ShortURL.credentials_for('bitly')
         username = creds['username'] 
         key = creds['key'] 
 

--- a/lib/shorturl/services/gitio.rb
+++ b/lib/shorturl/services/gitio.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Gitio < Service
 
-      def initialize
+      def initialize(creds = nil)
         super('git.io')
 
         @code = 201

--- a/lib/shorturl/services/isgd.rb
+++ b/lib/shorturl/services/isgd.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Isgd < Service
 
-      def initialize
+      def initialize(creds = nil)
         super('is.gd')
 
         @method = :get

--- a/lib/shorturl/services/lns.rb
+++ b/lib/shorturl/services/lns.rb
@@ -2,7 +2,7 @@ module ShortURL
   module Services
     class Lns < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("ln-s.net")
 
         @method = :get

--- a/lib/shorturl/services/metamark.rb
+++ b/lib/shorturl/services/metamark.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Metamark < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("metamark.net")
 
         @action = "/add"

--- a/lib/shorturl/services/minilink.rb
+++ b/lib/shorturl/services/minilink.rb
@@ -2,7 +2,7 @@ module ShortURL
   module Services
     class Minilink < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("minilink.org")
 
         @method = :get

--- a/lib/shorturl/services/moourl.rb
+++ b/lib/shorturl/services/moourl.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class MooURL < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("moourl.com")
 
         @code = 302

--- a/lib/shorturl/services/shorl.rb
+++ b/lib/shorturl/services/shorl.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Shorl < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("shorl.com")
 
         @method = :get

--- a/lib/shorturl/services/snipurl.rb
+++ b/lib/shorturl/services/snipurl.rb
@@ -6,7 +6,7 @@ module ShortURL
     # registration.
     class SnipURL < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("snipurl.com")
 
         @action = "/site/index"

--- a/lib/shorturl/services/tinyurl.rb
+++ b/lib/shorturl/services/tinyurl.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class TinyURL < Service
 
-      def initialize
+      def initialize(creds = nil)
         super('tinyurl.com')
 
         @action = "/api-create.php"

--- a/lib/shorturl/services/url.rb
+++ b/lib/shorturl/services/url.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Url < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("url.ca")
 
         @method = :post

--- a/lib/shorturl/services/vamu.rb
+++ b/lib/shorturl/services/vamu.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Vamu < Service
 
-      def initialize
+      def initialize(creds = nil)
         super('va.mu')
 
         @method = :get

--- a/lib/shorturl/services/vurl.rb
+++ b/lib/shorturl/services/vurl.rb
@@ -4,7 +4,7 @@ module ShortURL
   module Services
     class Vurl < Service
 
-      def initialize
+      def initialize(creds = nil)
         super("vurl.me")
 
         @method = :get

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,4 @@
-gem 'rspec', '~> 2.4'
+gem 'rspec', '~> 2.6'
 require 'rspec'
 require 'shorturl'
 


### PR DESCRIPTION
I don't like the fact that credentials may only be provided using a configuration file in the home directory. As a solution I suggest inversion of control when dealing with credentials - the Service should not know where to ask for them, but expect them as provided on initialization. That makes it possible to supply them like

`ShortURL.shorten 'http://oh.my/very/long/url', :bitly, {'username' => 'joe', 'key' => 'key123'}`

The code in the PR is just a quick proposal for now. If it was to be accepted, I would also provide tests that are now missing.
